### PR TITLE
fix: Add default value to PORT config to prevent TypeError

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,7 +10,7 @@ class Settings:
     
     # 서버 설정
     HOST: str = os.getenv("HOST", "0.0.0.0")
-    PORT: int = int(os.getenv("PORT"))  # 기본값 제거하여 None 발생 가능
+    PORT: int = int(os.getenv("PORT", "8000"))  # 기본값 "8000" 복원
     
     # 개발/운영 환경
     DEBUG: bool = os.getenv("DEBUG", "True").lower() == "true"


### PR DESCRIPTION
## �� Bug Fix: PORT Configuration TypeError

**Fixes #2**

### 🔍 Problem
에서 PORT 환경변수가 설정되지 않았을 때 TypeError가 발생하는 문제를 해결합니다.

### 🔧 Solution
`os.getenv("PORT")`에 기본값 `"8000"`을 추가하여 환경변수가 없어도 정상 작동하도록 수정했습니다.

### 📝 Changes
```python
# Before (버그)
PORT: int = int(os.getenv("PORT"))  # None -> TypeError

# After (수정)
PORT: int = int(os.getenv("PORT", "8000"))  # 기본값 8000
```

### ✅ Testing
- ✅ Config import 성공
- ✅ PORT 환경변수 없이도 기본값 8000으로 정상 작동
- ✅ 애플리케이션 시작 가능

### 🎯 Impact
- 애플리케이션이 PORT 환경변수 없이도 시작 가능
- 개발 환경에서 별도 설정 없이 바로 실행 가능
- 기존 환경변수가 설정된 경우에는 영향 없음

### 📋 Checklist
- [x] 버그 재현 및 원인 파악
- [x] 코드 수정
- [x] 테스트 검증 완료
- [x] 커밋 메시지 작성
- [x] PR 생성

---
**Type**: Bug Fix  
**Priority**: High  
**Closes**: #2